### PR TITLE
Kokkos Tool integration hooks

### DIFF
--- a/GDBKokkos/__init__.py
+++ b/GDBKokkos/__init__.py
@@ -10,6 +10,10 @@ import gdb
 from GDBKokkos.printView import(
     printView
     )
+from GDBKokkos.printViewMetadata import(
+    printViewMetadata
+    )
 
 # This registers our class to the gdb runtime at "source" time.
 printView()
+printViewMetadata()

--- a/GDBKokkos/printViewMetadata.py
+++ b/GDBKokkos/printViewMetadata.py
@@ -73,7 +73,7 @@ class printViewMetadata(gdb.Command):
                         names.add(name)
             block = block.superblock
         handle = gdb.parse_and_eval(args.view)['m_map']['m_impl_handle'] 
-        dog = gdb.parse_and_eval("printData((void*)"+str(handle)+")")
+        gdb.parse_and_eval("(void)printData((void*)"+str(handle)+")")
         #view = gdb.parse_and_eval(args.view)
         #r = self.parseRanges(args.ranges)
         #arr = view2NumpyArray(view)[r]

--- a/GDBKokkos/printViewMetadata.py
+++ b/GDBKokkos/printViewMetadata.py
@@ -1,0 +1,91 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+#
+# Copyright 2020 Char Aznable <aznable.char.0083@gmail.com>
+# Description: Utilities for pretty-printing Kokkos::View
+#
+# Distributed under terms of the 3-clause BSD license.
+import re
+import gdb
+import argparse
+import numpy as np
+import pandas as pd
+from GDBKokkos.utils import (
+    name2type, foreachMemberOfClass,foreachBaseType,
+    pointer2numpy)
+
+class printViewMetadata(gdb.Command):
+    """gdb command that prints a Kokkos::View
+    """
+    def __init__(self):
+        # This registers the class to be used as a gdb command
+        super(printViewMetadata, self).__init__("printViewMetadata", gdb.COMMAND_DATA)
+
+    def parseArguments(self, inputArgs):
+        parser = argparse.ArgumentParser()
+        parser.add_argument("view", type=str,
+                            help="Name of the view object")
+        #parser.add_argument("ranges", type=int, nargs='*', default=[],
+        #                    help="Ranges for each of the dimension. Default to\
+        #                    print the entire view")
+        #parser.add_argument("--noIndex", action='store_true', default=False,
+        #                    help="Do not show the rank indices when printing the view")
+        return parser.parse_args(inputArgs.split())
+    def printKnowledge(self, view: gdb.Value):
+      data = view['m_map']['m_impl_handle']
+      #print(data)
+    def parseRanges(self, ranges : list):
+        """Convert input ranges into tuple of slices of numpy array
+
+
+        Args:
+            ranges (list): Input list of int as slicing index
+        Returns: tuple of slice objects
+        """
+        arr = np.array(ranges).astype(int)
+        assert (not arr.size % 2) or (not arr.size % 3),\
+            "Input ranges must be a series of doublets:\
+            begin0, end0, begin1,end1... or triplets:\
+            begin0, end0, stride0, begin1, end1, stride1..."
+        if not arr.size % 2:
+            arr = arr.reshape(-1, 2)
+        elif not arr.size % 3:
+            arr = arr.reshape(-1, 3)
+        return tuple( slice( *r ) for r in arr )
+
+    def invoke(self, inputArgs, from_tty):
+        args = self.parseArguments(inputArgs)
+        v = args.view
+        frame = gdb.selected_frame()
+        block = frame.block()
+        names = set()
+        while block:
+            if(block.is_global):
+                #print()
+                #print('global vars')
+                pass
+            for symbol in block:
+                if (symbol.is_argument or symbol.is_variable):
+                    name = symbol.name
+                    if not name in names:
+                        #print('{} = {}'.format(name, symbol.value(frame)))
+                        names.add(name)
+            block = block.superblock
+        handle = gdb.parse_and_eval(args.view)['m_map']['m_impl_handle'] 
+        dog = gdb.parse_and_eval("printData((void*)"+str(handle)+")")
+        #view = gdb.parse_and_eval(args.view)
+        #r = self.parseRanges(args.ranges)
+        #arr = view2NumpyArray(view)[r]
+        #if np.asarray(arr.shape).size <= 1:
+        #    print(arr)
+        #else:
+        #    idx = pd.MultiIndex.from_product([ np.arange(dim) for dim in arr.shape[:-1] ],
+        #                                     names=[f"Dim{iDim}" for iDim in range(len(arr.shape)-1)])
+        #    df = pd.DataFrame(arr.reshape(-1, arr.shape[-1])).set_index(idx)
+        #    with pd.option_context('display.max_seq_items', None,
+        #                           'display.max_rows', 99999,
+        #                           'display.max_colwidth', 2000,
+        #                           ):
+        #        print(df.to_string(index=not args.noIndex,
+        #                           header=not args.noIndex))

--- a/ToolExtensions/Makefile
+++ b/ToolExtensions/Makefile
@@ -1,0 +1,6 @@
+default: all
+
+all: kp_gdb_extension.so
+
+kp_gdb_extension.so: kp_gdb_extension.cpp
+	g++ -Wno-pointer-arith -O3 -fPIC -std=c++14 -shared -o kp_gdb_extension.so kp_gdb_extension.cpp

--- a/ToolExtensions/README.md
+++ b/ToolExtensions/README.md
@@ -1,0 +1,29 @@
+# GDBKokkos Runtime Tool
+
+This adds the ability to track a View's history (deep copies, where it was allocated) to the data GDBKokkos provides.
+
+## Usage
+
+First, do everything mentioned in the root README, this relies on the GDB python support above.
+
+Then, build the Kokkos tool library in this directory (in this directory, type "make")
+
+Finally, when you run your app in GDB, just load the Kokkos Tool:
+
+```bash
+KOKKOS_PROFILE_LIBRARY=/path/to/kp_gdb_extension.so gdb --args ./test
+```
+
+### Use the metadata printer
+
+As in the root README, remember to 
+
+```gdb
+py import GDBKokkos
+```
+
+Then, if you want to print out the metadata of a given View, just
+
+```gdb
+printViewMetadata myView
+```

--- a/ToolExtensions/kp_gdb_extension.cpp
+++ b/ToolExtensions/kp_gdb_extension.cpp
@@ -1,0 +1,173 @@
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// color printing code via:
+// https://gist.github.com/zyvitski/fb12f2ce6bc9d3b141f3bd4410a6f7cf
+enum class ansi_color_code : int {
+  black = 30,
+  red = 31,
+  green = 32,
+  yellow = 33,
+  blue = 34,
+  magenta = 35,
+  cyan = 36,
+  white = 37,
+  bright_black = 90,
+  bright_red = 91,
+  bright_green = 92,
+  bright_yellow = 93,
+  bright_blue = 94,
+  bright_magenta = 95,
+  bright_cyan = 96,
+  bright_white = 97,
+};
+template <typename printable>
+std::string print_as_color(printable const &value, ansi_color_code color) {
+  std::stringstream sstr;
+  sstr << "\033[1;" << static_cast<int>(color) << "m" << value << "\033[0m";
+  return sstr.str();
+}
+struct Representable {
+  virtual void printHeader() = 0;
+  virtual void printData(void *ptr) = 0;
+};
+
+struct SpaceHandle {
+  char name[64];
+};
+
+struct SH {
+  char name[64];
+};
+
+struct region_stack {
+  std::vector<std::string> regions;
+  std::string represent() {
+    std::string built = "";
+    int depth = 0;
+    for (auto region : regions) {
+      for (int x = 0; x < depth; ++x) {
+        built += " ";
+      }
+      built += region + "\n";
+      ++depth;
+    }
+    return built;
+  }
+};
+
+std::vector<Representable *> histories;
+using map_type = std::map<void *, region_stack>;
+map_type ptr_map;
+
+struct allocHistory : public Representable {
+  void printHeader() override {
+    std::cout << print_as_color("==============\n", ansi_color_code::blue);
+    std::cout << print_as_color("Allocated at\n", ansi_color_code::blue);
+    std::cout << print_as_color("==============\n", ansi_color_code::blue);
+  }
+  void printData(void *in_ptr) override {
+    void *ptr = in_ptr - 128;
+    std::cout << print_as_color(ptr_map[ptr].represent(),
+                                ansi_color_code::yellow);
+  }
+};
+
+region_stack current_regions;
+struct DeepCopyHistory {
+  struct Entry {
+    std::string other_end;
+    region_stack code_location;
+    std::string space;
+    void print() {
+      std::cout << print_as_color("View: ", ansi_color_code::blue) << other_end
+                << std::endl;
+      std::cout << print_as_color("Space: ", ansi_color_code::blue) << space
+                << std::endl;
+      std::cout << print_as_color("Region stack (next line)\n",
+                                  ansi_color_code::blue);
+      std::cout << print_as_color(code_location.represent(),
+                                  ansi_color_code::yellow);
+      std::cout << std::flush;
+    }
+  };
+  void print() {
+    for (auto entry : history) {
+      entry.print();
+    }
+  }
+  std::vector<Entry> history;
+};
+struct DeepCopyTracker : public Representable {
+  std::map<const void *, DeepCopyHistory> src_history;
+  std::map<const void *, DeepCopyHistory> dst_history;
+  void printHeader() override {
+    std::cout << print_as_color("==============\n", ansi_color_code::blue);
+    ;
+    std::cout << print_as_color("Deep Copies\n", ansi_color_code::blue);
+    ;
+    std::cout << print_as_color("==============\n", ansi_color_code::blue);
+    ;
+  }
+  void printData(void *in_ptr) override {
+    auto ptr = in_ptr;
+    std::cout << print_as_color("Copies from this view: \n",
+                                ansi_color_code::green)
+              << std::endl;
+    src_history[ptr].print();
+    std::cout << print_as_color("Copies to this view: \n",
+                                ansi_color_code::green)
+              << std::endl;
+    dst_history[ptr].print();
+  }
+  void register_deep_copy(SpaceHandle dst_handle, const char *dst_name,
+                          const void *dst_ptr, SpaceHandle src_handle,
+                          const char *src_name, const void *src_ptr,
+                          uint64_t size) {
+    src_history[dst_ptr].history.push_back(DeepCopyHistory::Entry{
+        std::string(src_name), current_regions, std::string(dst_handle.name)});
+    dst_history[src_ptr].history.push_back(DeepCopyHistory::Entry{
+        std::string(dst_name), current_regions, std::string(src_handle.name)});
+  }
+};
+DeepCopyTracker *deep_copies;
+void printData(void *ptr) {
+
+  for (auto *history : histories) {
+    history->printHeader();
+    history->printData(ptr);
+  }
+}
+extern "C" void kokkosp_init_library(int loadseq, uint64_t version,
+                                     uint32_t ndevinfos, void *devinfos) {
+  histories.push_back(new allocHistory());
+  deep_copies = new DeepCopyTracker();
+  histories.push_back(deep_copies);
+}
+extern "C" void kokkosp_allocate_data(SH h, const char *name, void *ptr,
+                                      uint64_t size) {
+  static int count;
+  ptr_map[ptr] = current_regions;
+}
+extern "C" void kokkosp_deallocate_data(SH h, const char *name, void *ptr,
+                                        uint64_t size) {
+  static int count;
+}
+extern "C" void kokkosp_push_profile_region(const char *region) {
+  current_regions.regions.push_back(std::string(region));
+}
+extern "C" void kokkosp_pop_profile_region() {
+  current_regions.regions.pop_back();
+}
+extern "C" void kokkosp_begin_deep_copy(SpaceHandle dst_handle,
+                                        const char *dst_name,
+                                        const void *dst_ptr,
+                                        SpaceHandle src_handle,
+                                        const char *src_name,
+                                        const void *src_ptr, uint64_t size) {
+  deep_copies->register_deep_copy(dst_handle, dst_name, dst_ptr, src_handle,
+                                  src_name, src_ptr, size);
+}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import setuptools
 
 setuptools.setup(
     name="GDBKokkos",
-    python_requires=">=3.8.10",
+    python_requires=">=3.8.6",
     version="0.0.3",
     description="GDB python modules for debugging Kokkos",
     long_description="see https://github.com/Char-Aznable/GDBKokkos",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import re
 import subprocess
 import pytest
 import textwrap
+import os
 
 @pytest.fixture(scope="module")
 def writeCPP(tmpdir_factory, request):
@@ -30,8 +31,17 @@ def writeCPP(tmpdir_factory, request):
     p = tmpdir_factory.mktemp(f"TestView{fnLayout}{fnShape}")
     fCXX = p.join("test.cpp")
     fCXX.write(textwrap.dedent(cpp))
+
+    cpp_tool = getattr(request.module, "cpp_tool", "")
+    fCXX2 = p.join("test_tools.cpp")
+    fCXX2.write(textwrap.dedent(cpp_tool))
+
     yield (p, fCXX)
 
+@pytest.fixture(scope="module")
+def generateToolLibrary(request):
+    libpath = request.config.rootdir.join("ToolExtensions").join("kp_gdb_extension.so")
+    yield (libpath)
 
 @pytest.fixture(scope="module")
 def generateCMakeProject(writeCPP):
@@ -67,7 +77,7 @@ def generateCMakeProject(writeCPP):
     fBuildDir = p.mkdir("build")
     with fBuildDir.as_cwd():
         cmdCmake = [f"cmake {fCMakeLists.dirpath().strpath} "
-                    f"-DCMAKE_CXX_COMPILER=x86_64-conda-linux-gnu-g++ "
+                    f"-DCMAKE_CXX_COMPILER=g++ "
                     f"-DCMAKE_CXX_STANDARD=14 "
                     f"-DCMAKE_CXX_FLAGS='-DDEBUG -O0 -g' "
                     f"-DCMAKE_VERBOSE_MAKEFILE=ON "
@@ -80,21 +90,26 @@ def generateCMakeProject(writeCPP):
                                encoding='utf-8')
         assert rMake.returncode == 0, f"Error with running make: {rMake.stderr}"
     fTest = fBuildDir.join("test")
-    yield (p, fBuildDir, fTest)
+    fTestTools = fBuildDir.join("test_tools")
+    yield (p, fBuildDir, fTest, fTestTools)
 
 
 @pytest.fixture
 def runGDB():
-    def _runGDB(content : str, fPath, executable : str):
+    def _runGDB(content : str, fPath, executable : str, toolLibrary=None):
         fPath.write(textwrap.dedent(content))
-        cmd = [f"gdb -batch "
+        cmd = [f"/home/dzpolia/src/spack/opt/spack/spack_path_placeholder/spack_path_placeholder/spack_path_placeholder/spack_path_placeholder/sp/linux-rhel7-skylake_avx512/gcc-10.2.0/gdb-9.2-c3eoeva76lojz5bh7mdsqq4qnqkqq7qu/bin/gdb -batch "
                f"{executable} "
                f"-x {fPath.realpath().strpath}"
                ]
+        new_env = os.environ
+        if toolLibrary is not None:
+          new_env["KOKKOS_PROFILE_LIBRARY"] = toolLibrary
         r = subprocess.run(cmd,
                            shell=True,
                            capture_output=True,
-                           encoding='utf-8'
+                           encoding='utf-8',
+			   env=new_env
                            )
         assert r.returncode == 0,f"GDB error: {r.stderr}"
         # Get the output from GDB since the last breakpoint mark


### PR DESCRIPTION
This adds Kokkos Tool tracking capabilities to the existing pretty print capability.

If you load the included tool, adds a `printViewMetadata` command that will show where a View was allocated, as well as a history of where it was deep_copied to and from.

Mostly meant as a proof of concept, I think this method in which Kokkos exports events, which a Tool tracks, and which GDB can look up, will be a really powerful one. Follow-up should include looking at what all debugging cases people would like supported